### PR TITLE
Add Tavily option for ddg-web-search-additive

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Optional: Set to use Tavily Search instead of DuckDuckGo
+# Get your API key at https://app.tavily.com
+# TAVILY_API_KEY=tvly-YOUR_API_KEY

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+ddgs
+tavily-python
+streamlit
+ollama

--- a/tools/web_search.py
+++ b/tools/web_search.py
@@ -1,16 +1,31 @@
+import os
 from ddgs import DDGS
 
 def search_web(query):
 
     results = []
 
-    with DDGS() as ddgs:
-        search_results = ddgs.text(query, max_results=5)
+    tavily_api_key = os.environ.get("TAVILY_API_KEY")
 
-        for r in search_results:
+    if tavily_api_key:
+        from tavily import TavilyClient
+
+        client = TavilyClient(api_key=tavily_api_key)
+        response = client.search(query=query, max_results=5)
+
+        for r in response["results"]:
             results.append({
                 "title": r["title"],
-                "url": r["href"]
+                "url": r["url"]
             })
+    else:
+        with DDGS() as ddgs:
+            search_results = ddgs.text(query, max_results=5)
+
+            for r in search_results:
+                results.append({
+                    "title": r["title"],
+                    "url": r["href"]
+                })
 
     return results


### PR DESCRIPTION
## Search Provider Migration: ddg-web-search-additive

Adds Tavily as an additional option while preserving existing provider behavior.

Introduces [Tavily](https://tavily.com), a search API optimized for LLM applications.

### Changes

All changes are complete. Here's a summary:

## Changes Made

### 1. `tools/web_search.py` — Modified
- Added `import os` for environment variable access
- Added Tavily branch: when `TAVILY_API_KEY` is set, uses `TavilyClient.search()` with `max_results=5`
- Maps Tavily results to the existing `{"title", "url"}` dict shape (Tavily uses `r["url"]` vs DuckDuckGo's `r["href"]`)
- Preserved the original DuckDuckGo path as the `else` branch — works without any API key
- Tavily import is deferred (inside the `if` block) so `tavily-python` is only needed when actually used

### 2. `requirements.txt` — Created (new file)
- Lists `ddgs`, `tavily-python`, `streamlit`, `ollama` (derived from README and imports)

### 3. `.env.example` — Created (new file)
- Documents `TAVILY_API_KEY` as optional, with signup link

No other files were modified. The `search_web()` function signature and return shape are unchanged, so `app.py` and `agents/executor_agent.py` continue to work without modification.
